### PR TITLE
reordering popup binding (fixing #27)

### DIFF
--- a/resources/views/components/leaflet.blade.php
+++ b/resources/views/components/leaflet.blade.php
@@ -32,10 +32,10 @@
        });
      @endif
     var marker = L.marker([{{$marker['lat'] ?? $marker[0]}}, {{$marker['long'] ?? $marker[1]}}]);
-    @if(isset($marker['info']))
-     marker.bindPopup(@json($marker['info']));
-    @endif
     marker.addTo(mymap);
+    @if(isset($marker['info']))
+    marker.bindPopup(@json($marker['info']));
+    @endif
     @endforeach
 
     @if($tileHost === 'mapbox')


### PR DESCRIPTION
As mentioned in the example on leaflet's homepage (https://leafletjs.com/SlavaUkraini/) the binding of the popup need to happen after the marker is added to the map.

This is a fix to #27.