### PR TITLE
Added support for LatLngBounds on Google Maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ php artisan vendor:publish --provider="Larswiegers\LaravelMaps\LaravelMapsServic
 ```
 
 ## Supported map types
-| What        | Basic map | Centerpoint | Basic markers | Zoomlevel | Can use different tiles | Can be used multiple times on the same page |
-| ----------- | :-------: | :---------: | :-----------: | :-------: | :---------------------: | :------------------------------------------ |
-| Leaflet     |     ✅     |      ✅      |       ✅       |     ✅     |            ✅            | ✅                                           |
-| Google maps |     ✅     |      ✅      |       ✅       |     ✅     |            ✅            | ❌                                           |
+| What        | Basic map | Different map types | Centerpoint | Basic markers | Use bounds | Zoomlevel | Can use different tiles | Can be used multiple times on the same page |
+| ----------- | :-------: | :-----------------: | :---------: | :-----------: | :--------: | :-------: | :---------------------: | :------------------------------------------ |
+| Leaflet     |     ✅     |          ❌          |      ✅      |       ✅       |     ❌      |     ✅     |            ✅            | ✅                                           |
+| Google maps |     ✅     |          ✅          |      ✅      |       ✅       |     ✅      |     ✅     |            ✅            | ❌                                           |
 
 #### Tilehosts
 ##### Openstreetmap
@@ -57,10 +57,10 @@ We provide a default value if you use mapbox. But if you want to customize it yo
 
 <x-maps-leaflet></x-maps-leaflet>
 
-// set the centerpoint of the map:
+// Set the centerpoint of the map:
 <x-maps-leaflet :centerPoint="['lat' => 52.16, 'long' => 5]"></x-maps-leaflet>
 
-// set a zoomlevel:
+// Set a zoomlevel:
 <x-maps-leaflet :zoomLevel="6"></x-maps-leaflet>
 
 // Set markers on the map:
@@ -74,15 +74,18 @@ By default we use the latest version of leaflet, but if you want to use a differ
 // Set leafletVersion to desired version:
 <x-maps-leaflet leafletVersion='1.9.4'></x-maps-leaflet>
 ```
-### Google maps
+### Google Maps
 ``` blade
-// Google maps
+// Google Maps
 
-// set the centerpoint of the map:
+// Set the centerpoint of the map:
 <x-maps-google :centerPoint="['lat' => 52.16, 'long' => 5]"></x-maps-google>
 
-// set a zoomlevel:
+// Set a zoomlevel:
 <x-maps-google :zoomLevel="6"></x-maps-google>
+
+// Set type of the map (roadmap, satellite, hybrid, terrain):
+<x-maps-google :mapType="'hybrid'"></x-maps-google>
 
 // Set markers on the map:
 <x-maps-google :markers="[['lat' => 52.16444513293423, 'long' => 5.985622388024091]]"></x-maps-google>

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ php artisan vendor:publish --provider="Larswiegers\LaravelMaps\LaravelMapsServic
 ```
 
 ## Supported map types
-| What          | Basic map     | Centerpoint  | Basic markers  | Zoomlevel  | Can use different tiles  | Can be used multiple times on the same page |
-| ------------- |:-------------:|:------------:|:--------------:|:----------:|:------------------------:|:--------------------------------------------|
-| Leaflet       | ✅            | ✅            | ✅             | ✅         | ✅                        | ✅                                           |
-| Google maps   | ✅            | ✅            | ✅             | ✅         | ✅                        | ❌                                           |
+| What        | Basic map | Centerpoint | Basic markers | Zoomlevel | Can use different tiles | Can be used multiple times on the same page |
+| ----------- | :-------: | :---------: | :-----------: | :-------: | :---------------------: | :------------------------------------------ |
+| Leaflet     |     ✅     |      ✅      |       ✅       |     ✅     |            ✅            | ✅                                           |
+| Google maps |     ✅     |      ✅      |       ✅       |     ✅     |            ✅            | ❌                                           |
 
 #### Tilehosts
 ##### Openstreetmap
@@ -89,6 +89,25 @@ By default we use the latest version of leaflet, but if you want to use a differ
 
 // You can customize the title for each markers:
 <x-maps-google :markers="[['lat' => 52.16444513293423, 'long' => 5.985622388024091, 'title' => 'Your Title']]"></x-maps-google>
+
+// Automatically adjust the map's view during initialization to encompass all markers:
+<x-maps-google
+    :markers="[
+        ['lat' => 46.056946, 'long' => 14.505752],
+        ['lat' => 41.902782, 'long' => 12.496365]
+    ]"            
+    :fitToBounds="true"
+></x-maps-google>
+
+// Position the map's center at the geometric midpoint of all markers:
+<x-maps-google
+    :markers="[
+        ['lat' => 46.056946, 'long' => 14.505752],
+        ['lat' => 41.902782, 'long' => 12.496365]
+    ]"            
+    :centerToBoundsCenter="true"
+    :zoomLevel="7"
+></x-maps-google>
 ```
 #### Google maps api key
 You can get an api key here:

--- a/resources/views/components/google.blade.php
+++ b/resources/views/components/google.blade.php
@@ -29,6 +29,7 @@ class='{{ $attributes["class"] }}'
         map{{$mapId}} = new google.maps.Map(document.getElementById("{{$mapId}}"), {
             center: { lat: {{$centerPoint['lat'] ?? $centerPoint[0]}}, lng: {{$centerPoint['long'] ?? $centerPoint[1]}} },
             zoom: {{$zoomLevel}},
+            mapTypeId: '{{$mapType}}'
         });
 
     function addInfoWindow(marker, message) {

--- a/resources/views/components/google.blade.php
+++ b/resources/views/components/google.blade.php
@@ -23,7 +23,7 @@ class='{{ $attributes["class"] }}'
 ></script>
 
 <script>
-    let map{{$mapId}} = "";
+    let map{{$mapId}} = "";  
 
     function initMap{{$mapId}}() {
         map{{$mapId}} = new google.maps.Map(document.getElementById("{{$mapId}}"), {
@@ -42,23 +42,38 @@ class='{{ $attributes["class"] }}'
         });
     }
 
-        @foreach($markers as $marker)
-            var marker{{ $loop->iteration }} = new google.maps.Marker({
-                position: {
-                    lat: {{$marker['lat'] ?? $marker[0]}},
-                    lng: {{$marker['long'] ?? $marker[1]}}
-                },
-                map: map{{$mapId}},
-                @if(isset($marker['title']))
-                title: "{{ $marker['title'] }}",
-                @endif
-                icon: @if(isset($marker['icon']))"{{ $marker['icon']}}" @else null @endif
-            });
+    @if($fitToBounds || $centerToBoundsCenter)
+    let bounds = new google.maps.LatLngBounds();
+    @endif
 
-            @if(isset($marker['info']))
-                addInfoWindow(marker{{ $loop->iteration }}, @json($marker['info']));
+    @foreach($markers as $marker)
+        var marker{{ $loop->iteration }} = new google.maps.Marker({
+            position: {
+                lat: {{$marker['lat'] ?? $marker[0]}},
+                lng: {{$marker['long'] ?? $marker[1]}}
+            },
+            map: map{{$mapId}},
+            @if(isset($marker['title']))
+            title: "{{ $marker['title'] }}",
             @endif
+            icon: @if(isset($marker['icon']))"{{ $marker['icon']}}" @else null @endif
+        });
 
+        @if(isset($marker['info']))
+            addInfoWindow(marker{{ $loop->iteration }}, @json($marker['info']));
+        @endif
+
+        @if($fitToBounds || $centerToBoundsCenter)
+        bounds.extend({lat: {{$marker['lat'] ?? $marker[0]}},lng: {{$marker['long'] ?? $marker[1]}}});
+        @endif
+
+        @if($fitToBounds)
+        map{{$mapId}}.fitBounds(bounds);
+        @endif        
         @endforeach
+
+        @if($centerToBoundsCenter)
+        map{{$mapId}}.setCenter(bounds.getCenter());
+        @endif
     }
 </script>

--- a/src/Components/Google.php
+++ b/src/Components/Google.php
@@ -8,14 +8,17 @@ use Illuminate\View\View;
 
 class Google extends Component
 {
-
     const DEFAULTMAPID = "defaultMapId";
 
-    static $mapHasBeenLoadedBefore = false;
+    public static $mapHasBeenLoadedBefore = false;
 
     public int $zoomLevel;
 
     public int $maxZoomLevel;
+
+    public bool $fitToBounds;
+
+    public bool $centerToBoundsCenter;
 
     public array $centerPoint;
 
@@ -25,17 +28,19 @@ class Google extends Component
 
     public $mapId;
 
-    public function __construct($centerPoint = [0,0], $markers = [], $zoomLevel = 13, $maxZoomLevel = 18, $tileHost = 'openstreetmap', $id = self::DEFAULTMAPID)
+    public function __construct($centerPoint = [0, 0], $markers = [], $zoomLevel = 13, $maxZoomLevel = 18, $fitToBounds = false, $centerToBoundsCenter = false, $tileHost = 'openstreetmap', $id = self::DEFAULTMAPID)
     {
         $this->centerPoint = $centerPoint;
         $this->zoomLevel = $zoomLevel;
         $this->maxZoomLevel = $maxZoomLevel;
+        $this->fitToBounds = $fitToBounds;
+        $this->centerToBoundsCenter = $centerToBoundsCenter;
         $this->markers = $markers;
         $this->tileHost = $tileHost;
         $this->mapId = $this->mapId = $id === self::DEFAULTMAPID ? Str::random() : $id;
     }
 
-    public function render() : View
+    public function render(): View
     {
         $markerArray = [];
 
@@ -51,6 +56,8 @@ class Google extends Component
             'centerPoint' => $this->centerPoint,
             'zoomLevel' => $this->zoomLevel,
             'maxZoomLevel' => $this->maxZoomLevel,
+            'fitToBounds' => $this->fitToBounds,
+            'centerToBoundsCenter' => $this->centerToBoundsCenter,
             'markers' => $this->markers,
             'markerArray' => $markerArray,
             'tileHost' => $this->tileHost,

--- a/src/Components/Google.php
+++ b/src/Components/Google.php
@@ -20,6 +20,8 @@ class Google extends Component
 
     public bool $centerToBoundsCenter;
 
+    public string $mapType;
+
     public array $centerPoint;
 
     public array $markers;
@@ -28,13 +30,14 @@ class Google extends Component
 
     public $mapId;
 
-    public function __construct($centerPoint = [0, 0], $markers = [], $zoomLevel = 13, $maxZoomLevel = 18, $fitToBounds = false, $centerToBoundsCenter = false, $tileHost = 'openstreetmap', $id = self::DEFAULTMAPID)
+    public function __construct($centerPoint = [0, 0], $markers = [], $zoomLevel = 13, $maxZoomLevel = 18, $fitToBounds = false, $centerToBoundsCenter = false, $mapType = 'roadmap', $tileHost = 'openstreetmap', $id = self::DEFAULTMAPID)
     {
         $this->centerPoint = $centerPoint;
         $this->zoomLevel = $zoomLevel;
         $this->maxZoomLevel = $maxZoomLevel;
         $this->fitToBounds = $fitToBounds;
         $this->centerToBoundsCenter = $centerToBoundsCenter;
+        $this->mapType = strtolower($mapType);
         $this->markers = $markers;
         $this->tileHost = $tileHost;
         $this->mapId = $this->mapId = $id === self::DEFAULTMAPID ? Str::random() : $id;
@@ -52,12 +55,17 @@ class Google extends Component
         self::$mapHasBeenLoadedBefore = true;
 
 
+        if (!empty($this->mapType) && !in_array($this->mapType, ['roadmap', 'satellite', 'hybrid', 'terrain'], true)) {
+            $this->mapType = 'roadmap';
+        }
+
         return view('maps::components.google', [
             'centerPoint' => $this->centerPoint,
             'zoomLevel' => $this->zoomLevel,
             'maxZoomLevel' => $this->maxZoomLevel,
             'fitToBounds' => $this->fitToBounds,
             'centerToBoundsCenter' => $this->centerToBoundsCenter,
+            'mapType' => $this->mapType,
             'markers' => $this->markers,
             'markerArray' => $markerArray,
             'tileHost' => $this->tileHost,

--- a/tests/Unit/GoogleMapsTest.php
+++ b/tests/Unit/GoogleMapsTest.php
@@ -73,4 +73,16 @@ final class GoogleMapsTest extends TestCase
         $this->assertStringContainsString('let bounds = new google.maps.LatLngBounds();', $content);
         $this->assertStringContainsString('.setCenter(bounds.getCenter())', $content);
     }
+
+    public function test_we_can_set_map_type()
+    {
+        $content = $this->getComponentRenderedContent("<x-maps-google :mapType=\"'hybrid'\"></x-maps-google>");
+        $this->assertStringContainsString("mapTypeId: 'hybrid'", $content);
+    }
+
+    public function test_that_invalid_map_type_fallbacks_to_default_map_type()
+    {
+        $content = $this->getComponentRenderedContent("<x-maps-google :mapType=\"'invalidtype'\"></x-maps-google>");
+        $this->assertStringContainsString("mapTypeId: 'roadmap'", $content);
+    }
 }

--- a/tests/Unit/GoogleMapsTest.php
+++ b/tests/Unit/GoogleMapsTest.php
@@ -59,4 +59,18 @@ final class GoogleMapsTest extends TestCase
         $content = $this->getComponentRenderedContent("<x-maps-google :markers=\"[['lat' => 38.716450, 'long' => 0.055684, 'info' => 'MarkerInfo']]\"></x-maps-google>");
         $this->assertStringContainsString('addInfoWindow(marker1, "MarkerInfo");', $content);
     }
+
+    public function test_we_can_set_fit_to_bounds()
+    {
+        $content = $this->getComponentRenderedContent("<x-maps-google :markers=\"[['lat' => 38.716450, 'long' => 0.055684]]\" :fitToBounds=\"true\"></x-maps-google>");
+        $this->assertStringContainsString('let bounds = new google.maps.LatLngBounds();', $content);
+        $this->assertStringContainsString('.fitBounds(bounds)', $content);
+    }
+
+    public function test_we_can_set_center_to_bounds_center()
+    {
+        $content = $this->getComponentRenderedContent("<x-maps-google :markers=\"[['lat' => 38.716450, 'long' => 0.055684]]\" :centerToBoundsCenter=\"true\"></x-maps-google>");
+        $this->assertStringContainsString('let bounds = new google.maps.LatLngBounds();', $content);
+        $this->assertStringContainsString('.setCenter(bounds.getCenter())', $content);
+    }
 }


### PR DESCRIPTION
Added two attributes (boolean) to enable\disable usage of two LatLngBounds functionalities for Google Maps.

**1. fitToBounds**
_Displays the maps to fit the bounds of all used markers so that all markers on the map are visible when the map loads._
````html
<x-maps-google
    :markers="[
        ['lat' => 46.056946, 'long' => 14.505752],
        ['lat' => 46.528753, 'long' => 12.145386],
        ['lat' => 45.454381 , 'long' => 12.145386],
        ['lat' => 45.454381, 'long' => 15.569000],
        ['lat' => 47.114349, 'long' => 13.136000]
    ]"
    :fitToBounds="true" 
></x-maps-google>
````

**2. centerToBoundsCenter**
Map is centered on the exact center of all used markers.
````html
<x-maps-google
    :markers="[
        ['lat' => 46.056946, 'long' => 14.505752],
        ['lat' => 46.528753, 'long' => 12.145386],
        ['lat' => 45.454381 , 'long' => 12.145386],
        ['lat' => 45.454381, 'long' => 15.569000],
        ['lat' => 47.114349, 'long' => 13.136000]
    ]"
    :centerToBoundsCenter="true"
   :zoomLevel="6"
></x-maps-google>
````

Both can be used at the same time or separately.