### PR TITLE
Update illuminate/support version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.1|^8.2",
         "gajus/dindent": "^2.0.2",
-        "illuminate/support": "^9.43|^v10.0.0|^11.0|^12.0",
+        "illuminate/support": "^9.43|^10.0|^11.0|^12.0|^13.0"
         "nesbot/carbon": "^2.63|^3.0",
         "ramsey/collection": "^1.2.2|^2.0"
     },


### PR DESCRIPTION
This pull request updates the `composer.json` file to expand support for newer versions of the `illuminate/support` package.

Dependency updates:

* Broadened the version constraint for `illuminate/support` to include `^13.0`, allowing the package to be installed with Laravel 13 and ensuring compatibility with the latest framework releases.